### PR TITLE
fix: token cache max age expects ms but got seconds

### DIFF
--- a/src/interceptor.js
+++ b/src/interceptor.js
@@ -1,5 +1,5 @@
 function getMaxAge (res) {
-  return res.expires_in;
+  return res.expires_in * 1000;
 }
 
 function headerFormatter (res) {

--- a/tests/interceptor.test.js
+++ b/tests/interceptor.test.js
@@ -54,11 +54,16 @@ describe('interceptor', function () {
       }
 
       let results = await test3x(req);
+
+      await delay(1000);
+
+      results.push(...await test3x(req));
+
       verify(results, {
         headers: { Authorization: 'Bearer foo0' }
       });
 
-      await delay(3000);
+      await delay(2000);
 
       results = await test3x(req);
       verify(results, {


### PR DESCRIPTION
Hi!

I stumbled over a small bug. The `interceptor` does not cache the token correctly.

There is a small hint at the end of `axios-token-interceptor`'s README.md saying that the `getMaxAge` method of the `tokenCache` expects milliseconds but authorization server return `expires_in` in seconds.

> Note that `expires_in` coming from your authorization server is expressed in seconds, so you'll need to convert it to  milliseconds when returning it to the `getMaxAge` function.

(https://github.com/sandrinodimattia/axios-token-interceptor#readme)

The existing test worked, cause the execution was too fast. Adding a small delay and executing the test again, shows that the token was not cached correctly.

Many thanks for maintaining this library! :)