### PR TITLE
TypeScript declarations

### DIFF
--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -1,0 +1,120 @@
+import { AxiosRequestConfig, AxiosInstance } from 'axios';
+
+/**
+ * [Client Authentication](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3) using [Client Password](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). 
+ */
+export interface OAuth2ClientAuthenticationPassword {
+    /**
+     * The client identifier issued to the client during the registration process described by [RFC6749 Section 2.2](https://datatracker.ietf.org/doc/html/rfc6749#section-2.2).
+     */
+    client_id: string;
+    /**
+     * The client secret. The client MAY omit the parameter if the client secret is an empty string.
+     */
+    client_secret: string;
+}
+
+/**
+ * [Authorization Code Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) Access Token Request as described in [RFC6749 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3).
+ */
+export interface OAuth2CodeGrantTokenRequest {
+    grant_type: 'authorization_code';
+    /**
+     * The authorization code received from the authorization server.
+     */
+    code: string;
+    /**
+     * REQUIRED, if the "redirect_uri" parameter was included in the authorization request as described in [Section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1), and their values MUST be identical.
+     */
+    redirect_uri?: string;
+}
+
+/**
+ * [Resource Owner Password Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3) Access Token Request as described in [RFC6749 Section 4.3.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2).
+ */
+export interface OAuth2OwnerCredentialsGrantTokenRequest {
+    grant_type: 'password';
+    /**
+     * The resource owner username.
+     */
+    username: string;
+    /**
+     * The resource owner password.
+     */
+    password: string;
+    /**
+     * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+     */
+    scope?: string;
+}
+
+/**
+ * [Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) Access Token Request as described in [RFC6749 Section 4.4.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2).
+ */
+export interface OAuth2ClientCredentialsGrantTokenRequest extends OAuth2ClientAuthenticationPassword {
+    grant_type: 'client_credentials';
+    /**
+     * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+     */
+    scope?: string;
+}
+
+/**
+ * Access Token Request using Refresh Token as described in [RFC6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6).
+ */
+export interface OAuth2RefreshTokenRequest {
+    grant_type: 'refresh_token';
+    /**
+     * The refresh token issued to the client.
+     */
+    refresh_token: string;
+    /**
+     * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+     * The requested scope MUST NOT include any scope not originally granted by the resource owner, and if omitted is treated as equal to the scope originally granted by the resource owner.
+     */
+     scope?: string;
+}
+
+/**
+ * Access Token Response as decribed in [RFC6749 Section 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
+ */
+export interface OAuth2TokenResponse {
+    /**
+     * The access token string as issued by the authorization server.
+     */
+    access_token: string,
+    /**
+     * The type of the token issued as described in [RFC6749 Section 7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1).
+     * Value is case insensitive.
+     */
+    token_type: string,
+    /**
+     * The lifetime in seconds of the access token.  For
+     * example, the value "3600" denotes that the access token will
+     * expire in one hour from the time the response was generated.
+     * If omitted, the authorization server SHOULD provide the
+     * expiration time via other means or document the default value.
+     */
+    expires_in?: number,
+    /**
+     * The refresh token, which can be used to obtain new access tokens using the same authorization grant as described in [RFC6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6).
+     */
+    refresh_token?: string;
+    /**
+     * OPTIONAL If identical to the scope requested by the client; otherwise, REQUIRED.
+     * The scope of the access token as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+     */
+    scope?: string;
+}
+
+export interface ClientFactoryOptions {
+    /**
+     * OAuth2 Token endpoint URL.
+     */
+    url: string;
+}
+
+export type ClientFactoryOptionsWithTokenRequest = ClientFactoryOptions&(OAuth2ClientAuthenticationPassword|{})&(OAuth2CodeGrantTokenRequest|OAuth2OwnerCredentialsGrantTokenRequest|OAuth2ClientCredentialsGrantTokenRequest|OAuth2RefreshTokenRequest);
+
+declare function ClientFactory(axios: (config?:AxiosRequestConfig) => AxiosInstance, options: ClientFactoryOptionsWithTokenRequest): (() => Promise<OAuth2TokenResponse>);
+export = ClientFactory;

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -72,7 +72,7 @@ export interface OAuth2RefreshTokenRequest {
      * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
      * The requested scope MUST NOT include any scope not originally granted by the resource owner, and if omitted is treated as equal to the scope originally granted by the resource owner.
      */
-     scope?: string;
+    scope?: string;
 }
 
 /**

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -1,120 +1,152 @@
-import { AxiosRequestConfig, AxiosInstance } from 'axios';
+import { AxiosRequestConfig, AxiosInstance } from "axios";
 
 /**
- * [Client Authentication](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3) using [Client Password](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). 
+ * [Client Authentication](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3)
+ * using [Client Password](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1).
  */
 export interface OAuth2ClientAuthenticationPassword {
-    /**
-     * The client identifier issued to the client during the registration process described by [RFC6749 Section 2.2](https://datatracker.ietf.org/doc/html/rfc6749#section-2.2).
-     */
-    client_id: string;
-    /**
-     * The client secret. The client MAY omit the parameter if the client secret is an empty string.
-     */
-    client_secret: string;
+  /**
+   * The client identifier issued to the client during the registration process
+   * described by [RFC6749 Section 2.2](https://datatracker.ietf.org/doc/html/rfc6749#section-2.2).
+   */
+  client_id: string;
+  /**
+   * The client secret.
+   * The client MAY omit the parameter if the client secret is an empty string.
+   */
+  client_secret: string;
 }
 
 /**
- * [Authorization Code Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) Access Token Request as described in [RFC6749 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3).
+ * [Authorization Code Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1)
+ * Access Token Request as described in
+ * [RFC6749 Section 4.1.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3).
  */
 export interface OAuth2CodeGrantTokenRequest {
-    grant_type: 'authorization_code';
-    /**
-     * The authorization code received from the authorization server.
-     */
-    code: string;
-    /**
-     * REQUIRED, if the "redirect_uri" parameter was included in the authorization request as described in [Section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1), and their values MUST be identical.
-     */
-    redirect_uri?: string;
+  grant_type: "authorization_code";
+  /**
+   * The authorization code received from the authorization server.
+   */
+  code: string;
+  /**
+   * REQUIRED, if the "redirect_uri" parameter was included in the authorization request
+   * as described in [Section 4.1.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1),
+   * and their values MUST be identical.
+   */
+  redirect_uri?: string;
 }
 
 /**
- * [Resource Owner Password Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3) Access Token Request as described in [RFC6749 Section 4.3.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2).
+ * [Resource Owner Password Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3)
+ * Access Token Request as described in
+ * [RFC6749 Section 4.3.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3.2).
  */
 export interface OAuth2OwnerCredentialsGrantTokenRequest {
-    grant_type: 'password';
-    /**
-     * The resource owner username.
-     */
-    username: string;
-    /**
-     * The resource owner password.
-     */
-    password: string;
-    /**
-     * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
-     */
-    scope?: string;
+  grant_type: "password";
+  /**
+   * The resource owner username.
+   */
+  username: string;
+  /**
+   * The resource owner password.
+   */
+  password: string;
+  /**
+   * The scope of the access request as described by
+   * [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+   */
+  scope?: string;
 }
 
 /**
- * [Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) Access Token Request as described in [RFC6749 Section 4.4.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2).
+ * [Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)
+ * Access Token Request as described in
+ * [RFC6749 Section 4.4.2](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2).
  */
-export interface OAuth2ClientCredentialsGrantTokenRequest extends OAuth2ClientAuthenticationPassword {
-    grant_type: 'client_credentials';
-    /**
-     * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
-     */
-    scope?: string;
+export interface OAuth2ClientCredentialsGrantTokenRequest
+  extends OAuth2ClientAuthenticationPassword {
+  grant_type: "client_credentials";
+  /**
+   * The scope of the access request as described by
+   * [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+   */
+  scope?: string;
 }
 
 /**
- * Access Token Request using Refresh Token as described in [RFC6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6).
+ * Access Token Request using Refresh Token as described in
+ * [RFC6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6).
  */
 export interface OAuth2RefreshTokenRequest {
-    grant_type: 'refresh_token';
-    /**
-     * The refresh token issued to the client.
-     */
-    refresh_token: string;
-    /**
-     * The scope of the access request as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
-     * The requested scope MUST NOT include any scope not originally granted by the resource owner, and if omitted is treated as equal to the scope originally granted by the resource owner.
-     */
-    scope?: string;
+  grant_type: "refresh_token";
+  /**
+   * The refresh token issued to the client.
+   */
+  refresh_token: string;
+  /**
+   * The scope of the access request as described by
+   * [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+   * The requested scope MUST NOT include any scope not originally granted by the resource owner,
+   * and if omitted is treated as equal to the scope originally granted by the resource owner.
+   */
+  scope?: string;
 }
 
 /**
- * Access Token Response as decribed in [RFC6749 Section 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
+ * Access Token Response as decribed in
+ * [RFC6749 Section 5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1).
  */
 export interface OAuth2TokenResponse {
-    /**
-     * The access token string as issued by the authorization server.
-     */
-    access_token: string,
-    /**
-     * The type of the token issued as described in [RFC6749 Section 7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1).
-     * Value is case insensitive.
-     */
-    token_type: string,
-    /**
-     * The lifetime in seconds of the access token.  For
-     * example, the value "3600" denotes that the access token will
-     * expire in one hour from the time the response was generated.
-     * If omitted, the authorization server SHOULD provide the
-     * expiration time via other means or document the default value.
-     */
-    expires_in?: number,
-    /**
-     * The refresh token, which can be used to obtain new access tokens using the same authorization grant as described in [RFC6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6).
-     */
-    refresh_token?: string;
-    /**
-     * OPTIONAL If identical to the scope requested by the client; otherwise, REQUIRED.
-     * The scope of the access token as described by [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
-     */
-    scope?: string;
+  /**
+   * The access token string as issued by the authorization server.
+   */
+  access_token: string;
+  /**
+   * The type of the token issued as described in
+   * [RFC6749 Section 7.1](https://datatracker.ietf.org/doc/html/rfc6749#section-7.1).
+   * Value is case insensitive.
+   */
+  token_type: string;
+  /**
+   * The lifetime in seconds of the access token.  For
+   * example, the value "3600" denotes that the access token will
+   * expire in one hour from the time the response was generated.
+   * If omitted, the authorization server SHOULD provide the
+   * expiration time via other means or document the default value.
+   */
+  expires_in?: number;
+  /**
+   * The refresh token, which can be used to obtain new access tokens
+   * using the same authorization grant as described in
+   * [RFC6749 Section 6](https://datatracker.ietf.org/doc/html/rfc6749#section-6).
+   */
+  refresh_token?: string;
+  /**
+   * OPTIONAL If identical to the scope requested by the client; otherwise, REQUIRED.
+   * The scope of the access token as described by
+   * [RFC6749 Section 3.3](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).
+   */
+  scope?: string;
 }
 
 export interface ClientFactoryOptions {
-    /**
-     * OAuth2 Token endpoint URL.
-     */
-    url: string;
+  /**
+   * OAuth2 Token endpoint URL.
+   */
+  url: string;
 }
 
-export type ClientFactoryOptionsWithTokenRequest = ClientFactoryOptions&(OAuth2ClientAuthenticationPassword|{})&(OAuth2CodeGrantTokenRequest|OAuth2OwnerCredentialsGrantTokenRequest|OAuth2ClientCredentialsGrantTokenRequest|OAuth2RefreshTokenRequest);
+export type ClientFactoryOptionsWithTokenRequest = ClientFactoryOptions &
+  (OAuth2ClientAuthenticationPassword | {}) &
+  (
+    | OAuth2CodeGrantTokenRequest
+    | OAuth2OwnerCredentialsGrantTokenRequest
+    | OAuth2ClientCredentialsGrantTokenRequest
+    | OAuth2RefreshTokenRequest
+  );
 
-declare function ClientFactory(axios: (config?:AxiosRequestConfig) => AxiosInstance, options: ClientFactoryOptionsWithTokenRequest): (() => Promise<OAuth2TokenResponse>);
+declare function ClientFactory(
+  axios: (config?: AxiosRequestConfig) => AxiosInstance,
+  options: ClientFactoryOptionsWithTokenRequest
+): () => Promise<OAuth2TokenResponse>;
 export = ClientFactory;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,2 @@
-export * as client from "./client";
-export * as interceptor from "./interceptor";
+export const client: typeof import("./client");
+export const interceptor: typeof import("./interceptor");

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,2 @@
+export * as client from "./client";
+export * as interceptor from "./interceptor";

--- a/src/interceptor.d.ts
+++ b/src/interceptor.d.ts
@@ -1,6 +1,9 @@
-import { AxiosRequestConfig } from 'axios';
-import AxiosTokenProvider from 'axios-token-interceptor';
-import ClientFactory from './client';
+import { AxiosRequestConfig } from "axios";
+import AxiosTokenProvider from "axios-token-interceptor";
+import ClientFactory from "./client";
 
-declare function InterceptorFactory(tokenProvider: AxiosTokenProvider, authenticate: ClientFactory): AxiosTokenProvider.TokenProvider;
+declare function InterceptorFactory(
+  tokenProvider: AxiosTokenProvider,
+  authenticate: ClientFactory
+): AxiosTokenProvider.TokenProvider;
 export = InterceptorFactory;

--- a/src/interceptor.d.ts
+++ b/src/interceptor.d.ts
@@ -1,0 +1,6 @@
+import { AxiosRequestConfig } from 'axios';
+import AxiosTokenProvider from 'axios-token-interceptor';
+import ClientFactory from './client';
+
+declare function InterceptorFactory(tokenProvider: AxiosTokenProvider, authenticate: ClientFactory): AxiosTokenProvider.TokenProvider;
+export = InterceptorFactory;


### PR DESCRIPTION
Closes #13.

This PR provides TypeScript declarations in `src`. At is it does not attempt to publish them to `dist` atm, as the question on _how to_ remains open.

See, since the declarations are manually written (as `.d.ts`), typescript compiler _does not check them_ - as in does not emit declarations for declarations on compilation.

One possible solution (and a better one, imho, perhaps just because i'm more used to TS) is to
1. Merge the JavaScript `.js` and type declarations `.d.ts` into TypeScript `.ts` files
2. Use `@babel/preset-typescript` in combination with `@babel/preset-env` to transpile into JS
3. Use `tsc` with `emitDeclarationOnly` to verify & emit type declarations
(axios has type declarations itself; `axios-token-interceptor` has type definitions in [`@types`](https://www.npmjs.com/package/@types/axios-token-interceptor))

This however effectibely converts the package into being written in TS, which may or may not be desired 🤷‍♂️.

The other possible solution is to simply copy all `.d.ts` files into `dist` on `build`.