### PR TITLE
Added typescript types to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": {
+        "default": "./dist/index.d.ts"
+      }
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
The dist/index.d.ts wasn't included in the exports of package.json, resulting in linting errors.